### PR TITLE
added default value to var_lab getter

### DIFF
--- a/R/labels.R
+++ b/R/labels.R
@@ -67,9 +67,12 @@ var_lab=function(x){
 }
 
 #' @export
-var_lab.default=function(x){
-    attr(x,"label", exact = TRUE)
+var_lab.default=function (x, default=NULL) {
+    y=attr(x, "label", exact = TRUE)
+    if(is.null(y)) return(default)
+    y
 }
+
 
 #' @export
 var_lab.data.frame=function(x)


### PR DESCRIPTION
As suggested in https://github.com/gdemin/expss/issues/60, here is a PR.

It should now be possible to write:

```r
x=1:10
y=10:20

library(expss)
var_lab(x) = "I am X"
var_lab(x)
# "I am X"
var_lab(y)
# NULL
var_lab(y, default="I am Y")
# "I am Y"
```